### PR TITLE
Make twintail_cli independent of twintail_core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -147,9 +147,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "block-buffer"
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.21"
+version = "1.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
+checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
 dependencies = [
  "jobserver",
  "libc",
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -254,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -477,9 +477,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -653,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -673,9 +673,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -842,21 +842,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -866,30 +867,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -897,65 +878,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -971,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1036,7 +1004,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "libc",
 ]
 
@@ -1073,9 +1041,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libm"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1085,9 +1053,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -1369,6 +1337,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,7 +1440,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -1488,9 +1465,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags",
 ]
@@ -1625,9 +1602,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.26"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1647,15 +1624,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1911,12 +1891,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -1928,7 +1908,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1936,6 +1925,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1963,9 +1963,9 @@ checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1973,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2115,7 +2115,7 @@ dependencies = [
  "clap",
  "indicatif",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "twintail_common",
  "twintail_core",
@@ -2127,7 +2127,6 @@ name = "twintail_common"
 version = "0.0.0"
 dependencies = [
  "aes",
- "anstyle",
  "cbc",
  "clap",
  "hmac",
@@ -2135,7 +2134,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2146,7 +2145,6 @@ dependencies = [
  "futures",
  "hmac",
  "humansize",
- "indicatif",
  "rayon",
  "regex",
  "rmp-serde",
@@ -2154,7 +2152,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-retry",
  "twintail_common",
@@ -2175,7 +2173,7 @@ dependencies = [
  "serde_json",
  "serde_plain",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "twintail_common",
 ]
@@ -2214,12 +2212,6 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -2401,9 +2393,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
 dependencies = [
  "windows-link",
 ]
@@ -2573,16 +2565,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "xz2"
@@ -2595,9 +2581,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -2607,9 +2593,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2679,10 +2665,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2691,9 +2688,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2702,9 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.6.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
 dependencies = [
  "aes",
  "arbitrary",
@@ -2713,14 +2710,16 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "deflate64",
+ "displaydoc",
  "flate2",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "hmac",
  "indexmap",
  "lzma-rs",
  "memchr",
  "pbkdf2",
  "sha1",
+ "thiserror 2.0.12",
  "time",
  "xz2",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -1044,6 +1045,15 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6489ca9bd760fe9642d7644e827b0c9add07df89857b0416ee15c1cc1a3b8c5a"
+dependencies = [
+ "zlib-rs",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1908,16 +1918,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
-dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1925,17 +1926,6 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2115,7 +2105,7 @@ dependencies = [
  "clap",
  "indicatif",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "twintail_common",
  "twintail_core",
@@ -2134,7 +2124,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "sha2",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -2152,7 +2142,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "tokio-retry",
  "twintail_common",
@@ -2173,7 +2163,7 @@ dependencies = [
  "serde_json",
  "serde_plain",
  "sha2",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "twintail_common",
 ]
@@ -2699,18 +2689,16 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
 dependencies = [
  "aes",
  "arbitrary",
  "bzip2",
  "constant_time_eq",
  "crc32fast",
- "crossbeam-utils",
  "deflate64",
- "displaydoc",
  "flate2",
  "getrandom 0.3.3",
  "hmac",
@@ -2719,13 +2707,18 @@ dependencies = [
  "memchr",
  "pbkdf2",
  "sha1",
- "thiserror 2.0.12",
  "time",
  "xz2",
  "zeroize",
  "zopfli",
  "zstd",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ sha2 = "0.10.8"
 thiserror = "1.0.66"
 tokio = { version = "1.41.0", features = ["full"] }
 tokio-retry = "0.3.0"
-zip = "2.2.1"
+zip = "3.0.0"
 mockito = "1.5.0"
 tempfile = "3.13.0"
 

--- a/crates/twintail_cli/src/color.rs
+++ b/crates/twintail_cli/src/color.rs
@@ -1,0 +1,32 @@
+use anstyle::{AnsiColor, Color};
+use clap::builder::Styles;
+
+// general colors
+pub const TEXT: Color = Color::Ansi(AnsiColor::White);
+pub const TEXT_VARIANT: Color = Color::Ansi(AnsiColor::BrightCyan);
+pub const SUCCESS: Color = Color::Ansi(AnsiColor::BrightCyan);
+pub const ERROR: Color = Color::Ansi(AnsiColor::Red);
+pub const WARNING: Color = Color::Ansi(AnsiColor::BrightYellow);
+
+const USAGE: Color = Color::Ansi(AnsiColor::BrightBlue);
+const HEADER: Color = Color::Ansi(AnsiColor::BrightBlue);
+const LITERAL: Color = Color::Ansi(AnsiColor::BrightCyan);
+const INVALID: Color = Color::Ansi(AnsiColor::Red);
+const VALID: Color = Color::Ansi(AnsiColor::BrightCyan);
+const PLACEHOLDER: Color = Color::Ansi(AnsiColor::White);
+
+pub fn get_clap_styles() -> Styles {
+    Styles::styled()
+        .usage(anstyle::Style::new().bold().fg_color(Some(USAGE)))
+        .header(anstyle::Style::new().bold().fg_color(Some(HEADER)))
+        .literal(anstyle::Style::new().fg_color(Some(LITERAL)))
+        .invalid(anstyle::Style::new().bold().fg_color(Some(INVALID)))
+        .error(anstyle::Style::new().bold().fg_color(Some(ERROR)))
+        .valid(
+            anstyle::Style::new()
+                .bold()
+                .underline()
+                .fg_color(Some(VALID)),
+        )
+        .placeholder(anstyle::Style::new().fg_color(Some(PLACEHOLDER)))
+}

--- a/crates/twintail_cli/src/error.rs
+++ b/crates/twintail_cli/src/error.rs
@@ -10,4 +10,7 @@ pub enum Error {
 
     #[error("JSON de/serialization error: {0}")]
     SerdeJson(#[from] serde_json::Error),
+
+    #[error("tokio join error")]
+    TokioJoin(#[from] tokio::task::JoinError),
 }

--- a/crates/twintail_cli/src/lib.rs
+++ b/crates/twintail_cli/src/lib.rs
@@ -1,17 +1,17 @@
+mod color;
 mod error;
 mod strings;
 mod subcommands;
 
+use color::get_clap_styles;
 pub use error::Error;
 
-use anstyle::{AnsiColor, Color};
-use clap::{Parser, Subcommand, builder::Styles};
+use clap::{Parser, Subcommand};
 use subcommands::{
     app_info,
     crypt::{decrypt, encrypt},
     fetch,
 };
-use twintail_common::color;
 
 #[derive(Debug, Subcommand)]
 enum Commands {
@@ -54,27 +54,4 @@ pub async fn run() -> Result<(), clap::Error> {
     }
 
     Ok(())
-}
-
-/// Get styles for ``clap``.
-const USAGE: Color = Color::Ansi(AnsiColor::BrightBlue);
-const HEADER: Color = Color::Ansi(AnsiColor::BrightBlue);
-const LITERAL: Color = Color::Ansi(AnsiColor::BrightCyan);
-const INVALID: Color = Color::Ansi(AnsiColor::Red);
-const VALID: Color = Color::Ansi(AnsiColor::BrightCyan);
-const PLACEHOLDER: Color = Color::Ansi(AnsiColor::White);
-fn get_clap_styles() -> Styles {
-    Styles::styled()
-        .usage(anstyle::Style::new().bold().fg_color(Some(USAGE)))
-        .header(anstyle::Style::new().bold().fg_color(Some(HEADER)))
-        .literal(anstyle::Style::new().fg_color(Some(LITERAL)))
-        .invalid(anstyle::Style::new().bold().fg_color(Some(INVALID)))
-        .error(anstyle::Style::new().bold().fg_color(Some(color::ERROR)))
-        .valid(
-            anstyle::Style::new()
-                .bold()
-                .underline()
-                .fg_color(Some(VALID)),
-        )
-        .placeholder(anstyle::Style::new().fg_color(Some(PLACEHOLDER)))
 }

--- a/crates/twintail_cli/src/strings.rs
+++ b/crates/twintail_cli/src/strings.rs
@@ -10,9 +10,20 @@ pub mod crypto {
 }
 
 pub mod command {
+    pub const DOWNLOADING: &str = "Downloading files...";
+    pub const DOWNLOADED: &str = "downloaded";
+
+    // suite
+    pub const SUITE_VERSION: &str = "[Suite Data Version]:";
+
     // ab-info
+    pub const RETRIEVING_AB_INFO: &str = "Retrieving assetbundle info...";
     pub const COMMUNICATING: &str = "Communicating with game servers...";
     pub const PATHS_SAVED_TO: &str = "Paths saved to ";
+
+    // assetbundle
+    pub const INVALID_RE: &str =
+        "Invalid filter regular expression provided. No filter will be applied.";
 
     // extract hash
     pub const EXTRACTING: &str = "Extracting version and hash from file...";

--- a/crates/twintail_cli/src/strings.rs
+++ b/crates/twintail_cli/src/strings.rs
@@ -17,6 +17,7 @@ pub mod command {
     pub const SUITE_VERSION: &str = "[Suite Data Version]:";
     pub const SUITE_PROCESSING: &str = "Processing suitemaster files...";
     pub const SUITE_SAVING: &str = "Saving encrypted suitemaster files...";
+    pub const SUITE_DECRYPTING: &str = "Decrypting suitemaster files...";
 
     // ab-info
     pub const RETRIEVING_AB_INFO: &str = "Retrieving assetbundle info...";

--- a/crates/twintail_cli/src/strings.rs
+++ b/crates/twintail_cli/src/strings.rs
@@ -15,6 +15,8 @@ pub mod command {
 
     // suite
     pub const SUITE_VERSION: &str = "[Suite Data Version]:";
+    pub const SUITE_PROCESSING: &str = "Processing suitemaster files...";
+    pub const SUITE_SAVING: &str = "Saving encrypted suitemaster files...";
 
     // ab-info
     pub const RETRIEVING_AB_INFO: &str = "Retrieving assetbundle info...";
@@ -42,4 +44,8 @@ pub mod command {
     pub const INHERIT_CANCELLED: &str = "Save download was cancelled";
     pub const INHERIT_NO_CREDENTIAL: &str =
         "The credential contained in the inherit data was None.";
+    pub const INHERIT_GETTING_USER_DATA: &str = "Getting player information...";
+    pub const INHERIT_LOGGING_IN: &str = "Logging into your account...";
+    pub const INHERIT_GETTING_SAVE_DATA: &str = "Retrieving your account's save data...";
+    pub const INHERIT_FINISH_WARNING: &str = "Don't forget to use the same transfer ID and password to transfer your account back to its original device.";
 }

--- a/crates/twintail_cli/src/subcommands/app_info.rs
+++ b/crates/twintail_cli/src/subcommands/app_info.rs
@@ -2,10 +2,9 @@ use std::time::Duration;
 
 use clap::Args;
 use indicatif::ProgressBar;
-use twintail_common::color;
 use twintail_core::apk_extractor::ApkExtractor;
 
-use crate::{Error, strings};
+use crate::{Error, color, strings};
 
 #[derive(Debug, Args)]
 pub struct AppInfoArgs {

--- a/crates/twintail_cli/src/subcommands/crypt/decrypt/ab.rs
+++ b/crates/twintail_cli/src/subcommands/crypt/decrypt/ab.rs
@@ -74,18 +74,16 @@ async fn watch_decrypt_ab_state(mut receiver: Receiver<CryptState>) {
 
 /// Decrypts a file/folder using the provided arguments.
 pub async fn decrypt_ab(args: DecryptAbArgs) -> Result<(), Error> {
-    let quiet = args.quiet;
     let crypt_start_instant = Instant::now();
 
     let config = CryptConfig::builder()
         .recursive(args.recursive)
-        .quiet(quiet)
         .map(args.concurrent, |config, val| config.concurrency(val))
         .build();
 
     let (decrypter, state_recv) = Decrypter::new(config);
 
-    let state_watcher = if quiet {
+    let state_watcher = if args.quiet {
         None
     } else {
         Some(tokio::spawn(watch_decrypt_ab_state(state_recv)))

--- a/crates/twintail_cli/src/subcommands/crypt/decrypt/ab.rs
+++ b/crates/twintail_cli/src/subcommands/crypt/decrypt/ab.rs
@@ -1,8 +1,10 @@
-use crate::Error;
+use crate::{Error, color, strings};
 use clap::Args;
+use tokio::{sync::watch::Receiver, time::Instant};
+use twintail_common::utils::progress::ProgressBar;
 use twintail_core::{
     config::{OptionalBuilder, crypt_config::CryptConfig},
-    decrypt::Decrypter,
+    crypto::{CryptAssetbundlePathState, CryptState, decrypt::Decrypter},
 };
 
 #[derive(Debug, Args)]
@@ -26,19 +28,85 @@ pub struct DecryptAbArgs {
     pub out_path: Option<String>,
 }
 
+/// Watches a [`tokio::sync::watch::Receiver`] for state changes.
+///
+/// Prints information related to the progress of an assetbundle decrypt.
+async fn watch_decrypt_ab_state(mut receiver: Receiver<CryptState>) {
+    let mut progress_bar: Option<indicatif::ProgressBar> = None;
+    while receiver.changed().await.is_ok() {
+        match *receiver.borrow_and_update() {
+            CryptState::AssetbundlePath(CryptAssetbundlePathState::Scan) => {
+                println!(
+                    "{}[1/2] {}Scanning files...",
+                    color::TEXT_VARIANT.render_fg(),
+                    color::TEXT.render_fg()
+                );
+                progress_bar = Some(ProgressBar::spinner())
+            }
+            CryptState::AssetbundlePath(CryptAssetbundlePathState::Crypt(file_count)) => {
+                if let Some(spinner) = &progress_bar {
+                    spinner.finish_and_clear();
+                }
+
+                println!(
+                    "{}[2/2] {}{} files...",
+                    color::TEXT_VARIANT.render_fg(),
+                    color::TEXT.render_fg(),
+                    strings::crypto::decrypt::PROCESS,
+                );
+                progress_bar = Some(ProgressBar::progress(file_count as u64))
+            }
+            CryptState::AssetbundlePath(CryptAssetbundlePathState::CryptFile) => {
+                if let Some(progress) = &progress_bar {
+                    progress.inc(1);
+                }
+            }
+            CryptState::AssetbundlePath(CryptAssetbundlePathState::Finish) => {
+                if let Some(progress) = &progress_bar {
+                    progress.finish_and_clear();
+                }
+                break;
+            }
+            _ => {}
+        }
+    }
+}
+
 /// Decrypts a file/folder using the provided arguments.
 pub async fn decrypt_ab(args: DecryptAbArgs) -> Result<(), Error> {
+    let quiet = args.quiet;
+    let crypt_start_instant = Instant::now();
+
     let config = CryptConfig::builder()
         .recursive(args.recursive)
-        .quiet(args.quiet)
+        .quiet(quiet)
         .map(args.concurrent, |config, val| config.concurrency(val))
         .build();
 
-    let decrypter = Decrypter::new(config);
+    let (decrypter, state_recv) = Decrypter::new(config);
 
-    decrypter
+    let state_watcher = if quiet {
+        None
+    } else {
+        Some(tokio::spawn(watch_decrypt_ab_state(state_recv)))
+    };
+
+    let (decrypt_count, total_file_count) = decrypter
         .decrypt_ab_path(args.in_path, args.out_path)
         .await?;
+
+    if let Some(watcher) = state_watcher {
+        watcher.await?;
+        println!(
+            "{}Successfully {} {} / {} files in {:?}.{}",
+            color::SUCCESS.render_fg(),
+            strings::crypto::encrypt::PROCESSED,
+            decrypt_count,
+            total_file_count,
+            Instant::now().duration_since(crypt_start_instant),
+            color::TEXT.render_fg(),
+        );
+    }
 
     Ok(())
 }

--- a/crates/twintail_cli/src/subcommands/crypt/decrypt/json.rs
+++ b/crates/twintail_cli/src/subcommands/crypt/decrypt/json.rs
@@ -25,10 +25,7 @@ pub struct DecryptJsonArgs {
 pub async fn decrypt_json(args: DecryptJsonArgs) -> Result<(), Error> {
     let quiet = args.quiet;
 
-    let config = CryptConfig::builder()
-        .server(args.server)
-        .quiet(quiet)
-        .build();
+    let config = CryptConfig::builder().server(args.server).build();
 
     let (decrypter, _) = Decrypter::new(config);
 

--- a/crates/twintail_cli/src/subcommands/crypt/decrypt/json.rs
+++ b/crates/twintail_cli/src/subcommands/crypt/decrypt/json.rs
@@ -1,8 +1,8 @@
-use crate::{Error, strings};
+use crate::{Error, color, strings};
 use clap::Args;
 use tokio::time::Instant;
-use twintail_common::{color, models::enums::Server};
-use twintail_core::{config::crypt_config::CryptConfig, decrypt::Decrypter};
+use twintail_common::models::enums::Server;
+use twintail_core::{config::crypt_config::CryptConfig, crypto::decrypt::Decrypter};
 
 #[derive(Debug, Args)]
 pub struct DecryptJsonArgs {
@@ -30,7 +30,7 @@ pub async fn decrypt_json(args: DecryptJsonArgs) -> Result<(), Error> {
         .quiet(quiet)
         .build();
 
-    let decrypter = Decrypter::new(config);
+    let (decrypter, _) = Decrypter::new(config);
 
     let in_path = args.in_path;
     let out_path = args.out_path.unwrap_or(in_path.clone());

--- a/crates/twintail_cli/src/subcommands/crypt/decrypt/suite.rs
+++ b/crates/twintail_cli/src/subcommands/crypt/decrypt/suite.rs
@@ -1,9 +1,12 @@
-use crate::Error;
+use std::time::Duration;
+
+use crate::{Error, color, strings};
 use clap::Args;
-use twintail_common::models::enums::Server;
+use tokio::{sync::watch::Receiver, time::Instant};
+use twintail_common::{models::enums::Server, utils::progress::ProgressBar};
 use twintail_core::{
     config::{OptionalBuilder, crypt_config::CryptConfig},
-    decrypt::Decrypter,
+    crypto::{CryptState, DecryptSuitePathState, decrypt::Decrypter},
 };
 
 #[derive(Debug, Args)]
@@ -35,23 +38,78 @@ pub struct DecryptSuiteArgs {
     pub out_path: String,
 }
 
+/// Watches a [`tokio::sync::watch::Receiver`] for state changes.
+///
+/// Prints information related to the progress of a suite decrypt.
+async fn watch_decrypt_suite_state(mut receiver: Receiver<CryptState>) {
+    let mut progress_bar: Option<indicatif::ProgressBar> = None;
+    while receiver.changed().await.is_ok() {
+        match *receiver.borrow_and_update() {
+            CryptState::DecryptSuitePath(DecryptSuitePathState::Start(file_count)) => {
+                println!(
+                    "{}[1/1] {}{}",
+                    color::TEXT_VARIANT.render_fg(),
+                    color::TEXT.render_fg(),
+                    strings::command::SUITE_DECRYPTING,
+                );
+                let decrypt_progress = ProgressBar::progress(file_count as u64);
+                decrypt_progress.enable_steady_tick(Duration::from_millis(200));
+                progress_bar = Some(decrypt_progress)
+            }
+            CryptState::DecryptSuitePath(DecryptSuitePathState::Decrypt) => {
+                if let Some(progress) = &progress_bar {
+                    progress.inc(1);
+                }
+            }
+            CryptState::DecryptSuitePath(DecryptSuitePathState::Finish) => {
+                if let Some(progress) = &progress_bar {
+                    progress.finish_and_clear();
+                }
+                break;
+            }
+            _ => {}
+        }
+    }
+}
+
 /// Decrypts encrypted suitemaster files into individual .json files.
 pub async fn decrypt_suite(args: DecryptSuiteArgs) -> Result<(), Error> {
+    let decrypt_start_instant = Instant::now();
+    let quiet = args.quiet;
+
     let config = CryptConfig::builder()
         .recursive(args.recursive)
         .server(args.server)
-        .quiet(args.quiet)
+        .quiet(quiet)
         .pretty_json(!args.compact)
         .map(args.concurrent, |config, concurrency| {
             config.concurrency(concurrency)
         })
         .build();
 
-    let decrypter = Decrypter::new(config);
+    let (decrypter, state_recv) = Decrypter::new(config);
 
-    decrypter
+    let state_watcher = if quiet {
+        None
+    } else {
+        Some(tokio::spawn(watch_decrypt_suite_state(state_recv)))
+    };
+
+    let success_count = decrypter
         .decrypt_suite_path(args.in_path, args.out_path)
         .await?;
+
+    if let Some(watcher) = state_watcher {
+        watcher.await?;
+        println!(
+            "{}Successfully {} {} files in {:?}.{}",
+            color::SUCCESS.render_fg(),
+            strings::crypto::decrypt::PROCESSED,
+            success_count,
+            Instant::now().duration_since(decrypt_start_instant),
+            color::TEXT.render_fg(),
+        );
+    }
 
     Ok(())
 }

--- a/crates/twintail_cli/src/subcommands/crypt/decrypt/suite.rs
+++ b/crates/twintail_cli/src/subcommands/crypt/decrypt/suite.rs
@@ -75,12 +75,10 @@ async fn watch_decrypt_suite_state(mut receiver: Receiver<CryptState>) {
 /// Decrypts encrypted suitemaster files into individual .json files.
 pub async fn decrypt_suite(args: DecryptSuiteArgs) -> Result<(), Error> {
     let decrypt_start_instant = Instant::now();
-    let quiet = args.quiet;
 
     let config = CryptConfig::builder()
         .recursive(args.recursive)
         .server(args.server)
-        .quiet(quiet)
         .pretty_json(!args.compact)
         .map(args.concurrent, |config, concurrency| {
             config.concurrency(concurrency)
@@ -89,7 +87,7 @@ pub async fn decrypt_suite(args: DecryptSuiteArgs) -> Result<(), Error> {
 
     let (decrypter, state_recv) = Decrypter::new(config);
 
-    let state_watcher = if quiet {
+    let state_watcher = if args.quiet {
         None
     } else {
         Some(tokio::spawn(watch_decrypt_suite_state(state_recv)))

--- a/crates/twintail_cli/src/subcommands/crypt/encrypt/ab.rs
+++ b/crates/twintail_cli/src/subcommands/crypt/encrypt/ab.rs
@@ -75,11 +75,9 @@ async fn watch_encrypt_ab_state(mut receiver: Receiver<CryptState>) {
 /// Encrypts a file/folder using the provided arguments.
 pub async fn encrypt_ab(args: EncryptAbArgs) -> Result<(), Error> {
     let crypt_start = Instant::now();
-    let quiet = args.quiet;
 
     let config = CryptConfig::builder()
         .recursive(args.recursive)
-        .quiet(quiet)
         .map(args.concurrent, |config, concurrency| {
             config.concurrency(concurrency)
         })
@@ -87,7 +85,7 @@ pub async fn encrypt_ab(args: EncryptAbArgs) -> Result<(), Error> {
 
     let (encrypter, state_recv) = Encrypter::new(config);
 
-    let state_watcher = if quiet {
+    let state_watcher = if args.quiet {
         None
     } else {
         Some(tokio::spawn(watch_encrypt_ab_state(state_recv)))

--- a/crates/twintail_cli/src/subcommands/crypt/encrypt/ab.rs
+++ b/crates/twintail_cli/src/subcommands/crypt/encrypt/ab.rs
@@ -36,7 +36,7 @@ pub async fn encrypt_ab(args: EncryptAbArgs) -> Result<(), Error> {
         })
         .build();
 
-    let encrypter = Encrypter::new(config);
+    let (encrypter, _) = Encrypter::new(config);
 
     encrypter
         .encrypt_ab_path(args.in_path, args.out_path)

--- a/crates/twintail_cli/src/subcommands/crypt/encrypt/ab.rs
+++ b/crates/twintail_cli/src/subcommands/crypt/encrypt/ab.rs
@@ -1,8 +1,10 @@
-use crate::Error;
+use crate::{Error, color, strings};
 use clap::Args;
+use tokio::{sync::watch::Receiver, time::Instant};
+use twintail_common::utils::progress::ProgressBar;
 use twintail_core::{
     config::{OptionalBuilder, crypt_config::CryptConfig},
-    encrypt::Encrypter,
+    crypto::{CryptAssetbundlePathState, CryptState, encrypt::Encrypter},
 };
 
 #[derive(Debug, Args)]
@@ -26,21 +28,87 @@ pub struct EncryptAbArgs {
     pub out_path: Option<String>,
 }
 
+/// Watches a [`tokio::sync::watch::Receiver`] for state changes.
+///
+/// Prints information related to the progress of an assetbundle encrypt.
+async fn watch_encrypt_ab_state(mut receiver: Receiver<CryptState>) {
+    let mut progress_bar: Option<indicatif::ProgressBar> = None;
+    while receiver.changed().await.is_ok() {
+        match *receiver.borrow_and_update() {
+            CryptState::AssetbundlePath(CryptAssetbundlePathState::Scan) => {
+                println!(
+                    "{}[1/2] {}Scanning files...",
+                    color::TEXT_VARIANT.render_fg(),
+                    color::TEXT.render_fg()
+                );
+                progress_bar = Some(ProgressBar::spinner())
+            }
+            CryptState::AssetbundlePath(CryptAssetbundlePathState::Crypt(file_count)) => {
+                if let Some(spinner) = &progress_bar {
+                    spinner.finish_and_clear();
+                }
+
+                println!(
+                    "{}[2/2] {}{} files...",
+                    color::TEXT_VARIANT.render_fg(),
+                    color::TEXT.render_fg(),
+                    strings::crypto::encrypt::PROCESS,
+                );
+                progress_bar = Some(ProgressBar::progress(file_count as u64))
+            }
+            CryptState::AssetbundlePath(CryptAssetbundlePathState::CryptFile) => {
+                if let Some(progress) = &progress_bar {
+                    progress.inc(1);
+                }
+            }
+            CryptState::AssetbundlePath(CryptAssetbundlePathState::Finish) => {
+                if let Some(progress) = &progress_bar {
+                    progress.finish_and_clear();
+                }
+                break;
+            }
+            _ => {}
+        }
+    }
+}
+
 /// Encrypts a file/folder using the provided arguments.
 pub async fn encrypt_ab(args: EncryptAbArgs) -> Result<(), Error> {
+    let crypt_start = Instant::now();
+    let quiet = args.quiet;
+
     let config = CryptConfig::builder()
         .recursive(args.recursive)
-        .quiet(args.quiet)
+        .quiet(quiet)
         .map(args.concurrent, |config, concurrency| {
             config.concurrency(concurrency)
         })
         .build();
 
-    let (encrypter, _) = Encrypter::new(config);
+    let (encrypter, state_recv) = Encrypter::new(config);
 
-    encrypter
+    let state_watcher = if quiet {
+        None
+    } else {
+        Some(tokio::spawn(watch_encrypt_ab_state(state_recv)))
+    };
+
+    let (encrypt_count, total_file_count) = encrypter
         .encrypt_ab_path(args.in_path, args.out_path)
         .await?;
+
+    if let Some(watcher) = state_watcher {
+        watcher.await?;
+        println!(
+            "{}Successfully {} {} / {} files in {:?}.{}",
+            color::SUCCESS.render_fg(),
+            strings::crypto::encrypt::PROCESSED,
+            encrypt_count,
+            total_file_count,
+            Instant::now().duration_since(crypt_start),
+            color::TEXT.render_fg(),
+        );
+    }
 
     Ok(())
 }

--- a/crates/twintail_cli/src/subcommands/crypt/encrypt/json.rs
+++ b/crates/twintail_cli/src/subcommands/crypt/encrypt/json.rs
@@ -1,8 +1,8 @@
-use crate::{Error, strings};
+use crate::{Error, color, strings};
 use clap::Args;
 use tokio::time::Instant;
-use twintail_common::{color, models::enums::Server};
-use twintail_core::{config::crypt_config::CryptConfig, encrypt::Encrypter};
+use twintail_common::models::enums::Server;
+use twintail_core::{config::crypt_config::CryptConfig, crypto::encrypt::Encrypter};
 
 #[derive(Debug, Args)]
 pub struct EncryptJsonArgs {

--- a/crates/twintail_cli/src/subcommands/crypt/encrypt/json.rs
+++ b/crates/twintail_cli/src/subcommands/crypt/encrypt/json.rs
@@ -25,10 +25,7 @@ pub struct EncryptJsonArgs {
 pub async fn encrypt_json(args: EncryptJsonArgs) -> Result<(), Error> {
     let quiet = args.quiet;
 
-    let config = CryptConfig::builder()
-        .server(args.server)
-        .quiet(quiet)
-        .build();
+    let config = CryptConfig::builder().server(args.server).build();
 
     let (encrypter, _) = Encrypter::new(config);
 

--- a/crates/twintail_cli/src/subcommands/crypt/encrypt/json.rs
+++ b/crates/twintail_cli/src/subcommands/crypt/encrypt/json.rs
@@ -30,7 +30,7 @@ pub async fn encrypt_json(args: EncryptJsonArgs) -> Result<(), Error> {
         .quiet(quiet)
         .build();
 
-    let encrypter = Encrypter::new(config);
+    let (encrypter, _) = Encrypter::new(config);
 
     let in_path = args.in_path;
     let out_path = args.out_path.unwrap_or(in_path.clone());

--- a/crates/twintail_cli/src/subcommands/crypt/encrypt/suite.rs
+++ b/crates/twintail_cli/src/subcommands/crypt/encrypt/suite.rs
@@ -1,9 +1,9 @@
 use clap::Args;
-use tokio::time::Instant;
-use twintail_common::{color, models::enums::Server};
+use tokio::{sync::watch::Receiver, time::Instant};
+use twintail_common::{color, models::enums::Server, utils::progress::ProgressBar};
 use twintail_core::{
     config::{OptionalBuilder, crypt_config::CryptConfig},
-    encrypt::Encrypter,
+    encrypt::{EncryptState, EncryptSuitePathState, EncryptSuiteValuesState, Encrypter},
 };
 
 use crate::{Error, strings};
@@ -37,25 +37,83 @@ pub struct EncryptSuiteArgs {
     pub out_path: String,
 }
 
+/// Watches a [`tokio::sync::watch::Receiver`] for state changes.
+///
+/// Prints information related to the progress of a suite download.
+async fn watch_encrypt_suite_state(mut receiver: Receiver<EncryptState>) {
+    let mut progress_bar: Option<indicatif::ProgressBar> = None;
+    while receiver.changed().await.is_ok() {
+        let fetch_state = receiver.borrow_and_update().clone();
+        match fetch_state {
+            EncryptState::SuitePath(EncryptSuitePathState::Process) => {
+                if let Some(spinner) = &progress_bar {
+                    spinner.finish_and_clear();
+                }
+
+                println!(
+                    "{}{}{}",
+                    color::TEXT_VARIANT.render_fg(),
+                    color::TEXT.render_fg(),
+                    strings::command::SUITE_PROCESSING,
+                );
+                progress_bar = Some(ProgressBar::spinner())
+            }
+            EncryptState::SuiteValues(EncryptSuiteValuesState::SerializeStart(count)) => {
+                if let Some(spinner) = &progress_bar {
+                    spinner.finish_and_clear();
+                }
+                
+                println!(
+                    "{}{}{}",
+                    color::TEXT_VARIANT.render_fg(),
+                    color::TEXT.render_fg(),
+                    strings::command::SUITE_SAVING,
+                );
+                progress_bar = Some(ProgressBar::progress(count as u64))
+            }
+            EncryptState::SuiteValues(EncryptSuiteValuesState::Serialize) => {
+                if let Some(progress) = &progress_bar {
+                    progress.inc(1);
+                }
+            }
+            EncryptState::SuiteValues(EncryptSuiteValuesState::Finish) => {
+                if let Some(progress) = &progress_bar {
+                    progress.finish_and_clear();
+                }
+                break;
+            }
+            _ => {}
+        }
+    }
+}
+
 pub async fn encrypt_suite(args: EncryptSuiteArgs) -> Result<(), Error> {
     let encrypt_start = Instant::now();
+    let quiet = args.quiet;
 
     let config = CryptConfig::builder()
         .recursive(args.recursive)
         .server(args.server)
-        .quiet(args.quiet)
+        .quiet(quiet)
         .map(args.concurrent, |config, concurrency| {
             config.concurrency(concurrency)
         })
         .build();
 
-    let encrypter = Encrypter::new(config);
+    let (encrypter, state_recv) = Encrypter::new(config);
+
+    let state_watcher = if quiet {
+        None
+    } else {
+        Some(tokio::spawn(watch_encrypt_suite_state(state_recv)))
+    };
 
     encrypter
         .encrypt_suite_path(args.in_path, args.out_path, args.split)
         .await?;
 
-    if !args.quiet {
+    if let Some(watcher) = state_watcher {
+        watcher.await?;
         println!(
             "{}Successfully {} suite master files in {:?}.{}",
             color::SUCCESS.render_fg(),

--- a/crates/twintail_cli/src/subcommands/crypt/encrypt/suite.rs
+++ b/crates/twintail_cli/src/subcommands/crypt/encrypt/suite.rs
@@ -84,12 +84,10 @@ async fn watch_encrypt_suite_state(mut receiver: Receiver<CryptState>) {
 
 pub async fn encrypt_suite(args: EncryptSuiteArgs) -> Result<(), Error> {
     let encrypt_start = Instant::now();
-    let quiet = args.quiet;
 
     let config = CryptConfig::builder()
         .recursive(args.recursive)
         .server(args.server)
-        .quiet(quiet)
         .map(args.concurrent, |config, concurrency| {
             config.concurrency(concurrency)
         })
@@ -97,7 +95,7 @@ pub async fn encrypt_suite(args: EncryptSuiteArgs) -> Result<(), Error> {
 
     let (encrypter, state_recv) = Encrypter::new(config);
 
-    let state_watcher = if quiet {
+    let state_watcher = if args.quiet {
         None
     } else {
         Some(tokio::spawn(watch_encrypt_suite_state(state_recv)))

--- a/crates/twintail_cli/src/subcommands/fetch/ab.rs
+++ b/crates/twintail_cli/src/subcommands/fetch/ab.rs
@@ -175,13 +175,11 @@ pub async fn fetch_ab(args: AbArgs) -> Result<(), Error> {
         .build();
 
     // build config
-    let quiet = args.quiet;
     let fetch_config = FetchConfig::builder(args.version, args.hash)
         .platform(args.platform)
         .server(args.server)
         .retry(args.retry)
         .decrypt(!args.encrypt)
-        .quiet(quiet)
         .map(args.concurrent, |config, concurrency| {
             config.concurrency(concurrency)
         })
@@ -191,7 +189,7 @@ pub async fn fetch_ab(args: AbArgs) -> Result<(), Error> {
     let (mut fetcher, state_recv) = Fetcher::new(fetch_config).await?;
 
     // spawn thread for watching state_recv
-    let state_watcher = if quiet {
+    let state_watcher = if args.quiet {
         None
     } else {
         Some(tokio::spawn(watch_fetch_ab_state(state_recv)))
@@ -199,7 +197,7 @@ pub async fn fetch_ab(args: AbArgs) -> Result<(), Error> {
 
     // download assetbundles
     let download_start = Instant::now();
-    let (success_count, total_file_count) = fetcher
+    let (success_count, total_file_count, _) = fetcher
         .download_ab(args.out_dir, download_ab_config)
         .await?;
 

--- a/crates/twintail_cli/src/subcommands/fetch/ab.rs
+++ b/crates/twintail_cli/src/subcommands/fetch/ab.rs
@@ -7,7 +7,6 @@ use tokio::{
     time::Instant,
 };
 use twintail_common::{
-    color,
     models::enums::{Platform, Server},
     utils::progress::ProgressBar,
 };
@@ -17,7 +16,7 @@ use twintail_core::{
 };
 use twintail_sekai::models::AssetbundleInfo;
 
-use crate::{Error, strings};
+use crate::{Error, color, strings};
 
 #[derive(Debug, Args)]
 pub struct AbArgs {
@@ -83,7 +82,7 @@ pub struct AbArgs {
 async fn watch_fetch_ab_state(mut receiver: Receiver<FetchState>) {
     let mut progress_bar: Option<indicatif::ProgressBar> = None;
     while receiver.changed().await.is_ok() {
-        let fetch_state = receiver.borrow_and_update().clone();
+        let fetch_state = *receiver.borrow_and_update();
         if let FetchState::DownloadAb(download_ab_state) = fetch_state {
             match download_ab_state {
                 DownloadAbState::RetrieveAbInfo => {

--- a/crates/twintail_cli/src/subcommands/fetch/ab.rs
+++ b/crates/twintail_cli/src/subcommands/fetch/ab.rs
@@ -3,7 +3,8 @@ use std::path::Path;
 use tokio::{
     fs::File,
     io::{AsyncReadExt, BufReader},
-    sync::watch::Receiver, time::Instant,
+    sync::watch::Receiver,
+    time::Instant,
 };
 use twintail_common::{
     color,

--- a/crates/twintail_cli/src/subcommands/fetch/ab.rs
+++ b/crates/twintail_cli/src/subcommands/fetch/ab.rs
@@ -3,15 +3,20 @@ use std::path::Path;
 use tokio::{
     fs::File,
     io::{AsyncReadExt, BufReader},
+    sync::watch::Receiver, time::Instant,
 };
-use twintail_common::models::enums::{Platform, Server};
+use twintail_common::{
+    color,
+    models::enums::{Platform, Server},
+    utils::progress::ProgressBar,
+};
 use twintail_core::{
     config::{OptionalBuilder, download_ab_config::DownloadAbConfig, fetch_config::FetchConfig},
-    fetch::Fetcher,
+    fetch::{DownloadAbState, FetchState, Fetcher},
 };
 use twintail_sekai::models::AssetbundleInfo;
 
-use crate::Error;
+use crate::{Error, strings};
 
 #[derive(Debug, Args)]
 pub struct AbArgs {
@@ -71,6 +76,62 @@ pub struct AbArgs {
     pub out_dir: String,
 }
 
+/// Watches a [`tokio::sync::watch::Receiver`] for DownloadSuite state changes.
+///
+/// Prints information related to the progress of a suite download.
+async fn watch_fetch_ab_state(mut receiver: Receiver<FetchState>) {
+    let mut progress_bar: Option<indicatif::ProgressBar> = None;
+    while receiver.changed().await.is_ok() {
+        let fetch_state = receiver.borrow_and_update().clone();
+        if let FetchState::DownloadAb(download_ab_state) = fetch_state {
+            match download_ab_state {
+                DownloadAbState::RetrieveAbInfo => {
+                    println!(
+                        "{}[1/2] {}{}",
+                        color::TEXT_VARIANT.render_fg(),
+                        color::TEXT.render_fg(),
+                        strings::command::RETRIEVING_AB_INFO,
+                    );
+                    progress_bar = Some(ProgressBar::spinner());
+                }
+                DownloadAbState::InvalidRegEx => {
+                    println!(
+                        "{}{}{}",
+                        color::ERROR.render_fg(),
+                        strings::command::INVALID_RE,
+                        color::TEXT.render_fg()
+                    )
+                }
+                DownloadAbState::DownloadStart(total_bytes) => {
+                    if let Some(spinner) = &progress_bar {
+                        spinner.finish_and_clear();
+                    }
+
+                    println!(
+                        "{}[2/2] {}{}",
+                        color::TEXT_VARIANT.render_fg(),
+                        color::TEXT.render_fg(),
+                        strings::command::DOWNLOADING,
+                    );
+
+                    progress_bar = Some(ProgressBar::download(total_bytes));
+                }
+                DownloadAbState::FileDownload(file_size_bytes) => {
+                    if let Some(progress) = &progress_bar {
+                        progress.inc(file_size_bytes);
+                    }
+                }
+                DownloadAbState::Finish => {
+                    if let Some(progress) = &progress_bar {
+                        progress.finish_and_clear();
+                    }
+                    break;
+                }
+            }
+        }
+    }
+}
+
 /// Reads and deserializes an assetbundle info from a .json file.
 async fn read_assetbundle_info(path: &str) -> Result<AssetbundleInfo, Error> {
     // read file
@@ -114,24 +175,46 @@ pub async fn fetch_ab(args: AbArgs) -> Result<(), Error> {
         .build();
 
     // build config
+    let quiet = args.quiet;
     let fetch_config = FetchConfig::builder(args.version, args.hash)
         .platform(args.platform)
         .server(args.server)
         .retry(args.retry)
         .decrypt(!args.encrypt)
-        .quiet(args.quiet)
+        .quiet(quiet)
         .map(args.concurrent, |config, concurrency| {
             config.concurrency(concurrency)
         })
         .build();
 
     // create fetcher
-    let mut fetcher = Fetcher::new(fetch_config).await?;
+    let (mut fetcher, state_recv) = Fetcher::new(fetch_config).await?;
+
+    // spawn thread for watching state_recv
+    let state_watcher = if quiet {
+        None
+    } else {
+        Some(tokio::spawn(watch_fetch_ab_state(state_recv)))
+    };
 
     // download assetbundles
-    fetcher
+    let download_start = Instant::now();
+    let (success_count, total_file_count) = fetcher
         .download_ab(args.out_dir, download_ab_config)
         .await?;
+
+    if let Some(watcher) = state_watcher {
+        watcher.await?;
+        println!(
+            "{}Successfully {} {} / {} files in {:?}{}",
+            color::SUCCESS.render_fg(),
+            strings::command::DOWNLOADED,
+            success_count,
+            total_file_count,
+            Instant::now().duration_since(download_start),
+            color::TEXT.render_fg(),
+        );
+    }
 
     Ok(())
 }

--- a/crates/twintail_cli/src/subcommands/fetch/abinfo.rs
+++ b/crates/twintail_cli/src/subcommands/fetch/abinfo.rs
@@ -71,7 +71,7 @@ pub async fn abinfo(args: AbInfoArgs) -> Result<(), Error> {
         .server(args.server)
         .quiet(args.quiet)
         .build();
-    let mut fetcher = Fetcher::new(fetch_config).await?;
+    let (mut fetcher, _) = Fetcher::new(fetch_config).await?;
 
     let assetbundle_info = fetcher
         .get_ab_info(args.asset_version, args.host_hash)

--- a/crates/twintail_cli/src/subcommands/fetch/abinfo.rs
+++ b/crates/twintail_cli/src/subcommands/fetch/abinfo.rs
@@ -66,7 +66,6 @@ pub async fn abinfo(args: AbInfoArgs) -> Result<(), Error> {
     let fetch_config = FetchConfig::builder(args.version, args.hash)
         .platform(args.platform)
         .server(args.server)
-        .quiet(args.quiet)
         .build();
     let (mut fetcher, _) = Fetcher::new(fetch_config).await?;
 

--- a/crates/twintail_cli/src/subcommands/fetch/abinfo.rs
+++ b/crates/twintail_cli/src/subcommands/fetch/abinfo.rs
@@ -5,13 +5,10 @@ use tokio::{
     fs::{File, create_dir_all},
     io::AsyncWriteExt,
 };
-use twintail_common::{
-    color,
-    models::enums::{Platform, Server},
-};
+use twintail_common::models::enums::{Platform, Server};
 use twintail_core::{config::fetch_config::FetchConfig, fetch::Fetcher};
 
-use crate::{Error, strings};
+use crate::{Error, color, strings};
 
 #[derive(Debug, Args)]
 pub struct AbInfoArgs {

--- a/crates/twintail_cli/src/subcommands/fetch/save.rs
+++ b/crates/twintail_cli/src/subcommands/fetch/save.rs
@@ -111,7 +111,6 @@ pub async fn fetch_save(args: SaveArgs) -> Result<(), Error> {
     // create fetcher
     let fetch_config = FetchConfig::builder(args.version, args.hash)
         .server(args.server)
-        .quiet(args.quiet)
         .pretty_json(!args.compact)
         .build();
     let (mut fetcher, state_recv) = Fetcher::new(fetch_config).await?;

--- a/crates/twintail_cli/src/subcommands/fetch/save.rs
+++ b/crates/twintail_cli/src/subcommands/fetch/save.rs
@@ -1,13 +1,13 @@
 use clap::Args;
 use std::io::{Write, stdin, stdout};
 use tokio::{sync::watch::Receiver, time::Instant};
-use twintail_common::{color, models::enums::Server, utils::progress::ProgressBar};
+use twintail_common::{models::enums::Server, utils::progress::ProgressBar};
 use twintail_core::{
     config::fetch_config::FetchConfig,
     fetch::{FetchState, Fetcher, GetUserInheritState, WriteUserSaveDataState},
 };
 
-use crate::{Error, strings};
+use crate::{Error, color, strings};
 
 #[derive(Debug, Args)]
 pub struct SaveArgs {
@@ -49,12 +49,11 @@ pub struct SaveArgs {
 
 /// Watches a [`tokio::sync::watch::Receiver`] for state changes.
 ///
-/// Prints information related to the progress of a suite download.
+/// Prints information related to the progress of a save fetch.
 async fn watch_fetch_save_state(mut receiver: Receiver<FetchState>) {
     let mut progress_bar: Option<indicatif::ProgressBar> = None;
     while receiver.changed().await.is_ok() {
-        let fetch_state = receiver.borrow_and_update().clone();
-        match fetch_state {
+        match *receiver.borrow_and_update() {
             FetchState::GetUserInherit(GetUserInheritState::GetInherit) => {
                 println!(
                     "{}{}{}",
@@ -73,7 +72,7 @@ async fn watch_fetch_save_state(mut receiver: Receiver<FetchState>) {
                 if let Some(spinner) = &progress_bar {
                     spinner.finish_and_clear();
                 }
-                
+
                 println!(
                     "{}{}{}",
                     color::TEXT_VARIANT.render_fg(),

--- a/crates/twintail_cli/src/subcommands/fetch/save.rs
+++ b/crates/twintail_cli/src/subcommands/fetch/save.rs
@@ -52,7 +52,7 @@ pub async fn fetch_save(args: SaveArgs) -> Result<(), Error> {
         .quiet(args.quiet)
         .pretty_json(!args.compact)
         .build();
-    let mut fetcher = Fetcher::new(fetch_config).await?;
+    let (mut fetcher, _) = Fetcher::new(fetch_config).await?;
 
     // fetch user inherit data
     let user_inherit = fetcher

--- a/crates/twintail_cli/src/subcommands/fetch/suite.rs
+++ b/crates/twintail_cli/src/subcommands/fetch/suite.rs
@@ -106,14 +106,12 @@ async fn watch_fetch_suite_state(mut receiver: Receiver<FetchState>) {
 }
 
 pub async fn fetch_suite(args: SuiteArgs) -> Result<(), Error> {
-    let quiet = args.quiet;
     // create fetcher
     let fetch_config = FetchConfig::builder(args.version, args.hash)
         .platform(args.platform)
         .server(args.server)
         .retry(args.retry)
         .decrypt(!args.encrypt)
-        .quiet(quiet)
         .pretty_json(!args.compact)
         .map(args.concurrent, |config, concurrency| {
             config.concurrency(concurrency)
@@ -121,7 +119,7 @@ pub async fn fetch_suite(args: SuiteArgs) -> Result<(), Error> {
         .build();
     let (mut fetcher, state_recv) = Fetcher::new(fetch_config).await?;
 
-    let state_watcher = if quiet {
+    let state_watcher = if args.quiet {
         None
     } else {
         Some(tokio::spawn(watch_fetch_suite_state(state_recv)))

--- a/crates/twintail_cli/src/subcommands/fetch/suite.rs
+++ b/crates/twintail_cli/src/subcommands/fetch/suite.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use clap::Args;
 use tokio::{sync::watch::Receiver, time::Instant};
 use twintail_common::{
-    color,
     models::enums::{Platform, Server},
     utils::progress::ProgressBar,
 };
@@ -12,7 +11,7 @@ use twintail_core::{
     fetch::{DownloadSuiteState, FetchState, Fetcher},
 };
 
-use crate::{Error, strings};
+use crate::{Error, color, strings};
 
 #[derive(Debug, Args)]
 pub struct SuiteArgs {
@@ -62,7 +61,7 @@ pub struct SuiteArgs {
 async fn watch_fetch_suite_state(mut receiver: Receiver<FetchState>) {
     let mut progress_bar: Option<indicatif::ProgressBar> = None;
     while receiver.changed().await.is_ok() {
-        let fetch_state = receiver.borrow_and_update().clone();
+        let fetch_state = *receiver.borrow_and_update();
         if let FetchState::DownloadSuite(download_suite_state) = fetch_state {
             match download_suite_state {
                 DownloadSuiteState::Communicate => {

--- a/crates/twintail_cli/src/subcommands/fetch/suite.rs
+++ b/crates/twintail_cli/src/subcommands/fetch/suite.rs
@@ -1,11 +1,18 @@
+use std::time::Duration;
+
 use clap::Args;
-use twintail_common::models::enums::{Platform, Server};
+use tokio::{sync::watch::Receiver, time::Instant};
+use twintail_common::{
+    color,
+    models::enums::{Platform, Server},
+    utils::progress::ProgressBar,
+};
 use twintail_core::{
     config::{OptionalBuilder, fetch_config::FetchConfig},
-    fetch::Fetcher,
+    fetch::{DownloadSuiteState, FetchState, Fetcher},
 };
 
-use crate::Error;
+use crate::{Error, strings};
 
 #[derive(Debug, Args)]
 pub struct SuiteArgs {
@@ -49,23 +56,101 @@ pub struct SuiteArgs {
     pub out_path: String,
 }
 
+/// Watches a [`tokio::sync::watch::Receiver`] for DownloadSuite state changes.
+///
+/// Prints information related to the progress of a suite download.
+async fn watch_fetch_suite_state(mut receiver: Receiver<FetchState>) {
+    let mut progress_bar: Option<indicatif::ProgressBar> = None;
+    while receiver.changed().await.is_ok() {
+        let fetch_state = receiver.borrow_and_update().clone();
+        if let FetchState::DownloadSuite(download_suite_state) = fetch_state {
+            match download_suite_state {
+                DownloadSuiteState::Communicate => {
+                    println!(
+                        "{}[1/2] {}{}",
+                        color::TEXT_VARIANT.render_fg(),
+                        color::TEXT.render_fg(),
+                        strings::command::COMMUNICATING,
+                    );
+                    progress_bar = Some(ProgressBar::spinner());
+                }
+                DownloadSuiteState::DownloadStart(file_count) => {
+                    if let Some(spinner) = &progress_bar {
+                        spinner.finish_and_clear();
+                    }
+
+                    println!(
+                        "{}[2/2] {}{}",
+                        color::TEXT_VARIANT.render_fg(),
+                        color::TEXT.render_fg(),
+                        strings::command::DOWNLOADING,
+                    );
+
+                    let progress = ProgressBar::progress(file_count as u64);
+                    progress.enable_steady_tick(Duration::from_millis(100));
+                    progress_bar = Some(progress);
+                }
+                DownloadSuiteState::FileDownload => {
+                    if let Some(progress) = &progress_bar {
+                        progress.inc(1);
+                    }
+                }
+                DownloadSuiteState::Finish => {
+                    if let Some(progress) = &progress_bar {
+                        progress.finish_and_clear();
+                    }
+                    break;
+                }
+            }
+        }
+    }
+}
+
 pub async fn fetch_suite(args: SuiteArgs) -> Result<(), Error> {
+    let quiet = args.quiet;
     // create fetcher
     let fetch_config = FetchConfig::builder(args.version, args.hash)
         .platform(args.platform)
         .server(args.server)
         .retry(args.retry)
         .decrypt(!args.encrypt)
-        .quiet(args.quiet)
+        .quiet(quiet)
         .pretty_json(!args.compact)
         .map(args.concurrent, |config, concurrency| {
             config.concurrency(concurrency)
         })
         .build();
-    let mut fetcher = Fetcher::new(fetch_config).await?;
+    let (mut fetcher, state_recv) = Fetcher::new(fetch_config).await?;
+
+    let state_watcher = if quiet {
+        None
+    } else {
+        Some(tokio::spawn(watch_fetch_suite_state(state_recv)))
+    };
 
     // download suitemaster files
-    fetcher.download_suite(args.out_path).await?;
+    let download_start = Instant::now();
+    let (downloaded_count, file_count, suite_version) = fetcher.download_suite(args.out_path).await?;
+
+    if let Some(watcher) = state_watcher {
+        watcher.await?;
+        println!(
+            "{}{} {}{}",
+            color::TEXT_VARIANT.render_fg(),
+            strings::command::SUITE_VERSION,
+            color::TEXT.render_fg(),
+            suite_version
+        );
+        println!(
+            "{}Successfully {} {} / {} files in {:?}{}",
+            color::SUCCESS.render_fg(),
+            strings::command::DOWNLOADED,
+            downloaded_count,
+            file_count,
+            Instant::now().duration_since(download_start),
+            color::TEXT.render_fg(),
+        );
+    }
 
     Ok(())
 }

--- a/crates/twintail_cli/src/subcommands/fetch/suite.rs
+++ b/crates/twintail_cli/src/subcommands/fetch/suite.rs
@@ -130,7 +130,8 @@ pub async fn fetch_suite(args: SuiteArgs) -> Result<(), Error> {
 
     // download suitemaster files
     let download_start = Instant::now();
-    let (downloaded_count, file_count, suite_version) = fetcher.download_suite(args.out_path).await?;
+    let (downloaded_count, file_count, suite_version) =
+        fetcher.download_suite(args.out_path).await?;
 
     if let Some(watcher) = state_watcher {
         watcher.await?;

--- a/crates/twintail_common/Cargo.toml
+++ b/crates/twintail_common/Cargo.toml
@@ -12,4 +12,3 @@ thiserror.workspace = true
 hmac.workspace = true
 sha2.workspace = true
 indicatif.workspace = true
-anstyle.workspace = true

--- a/crates/twintail_common/src/color.rs
+++ b/crates/twintail_common/src/color.rs
@@ -1,8 +1,0 @@
-use anstyle::{AnsiColor, Color};
-
-// general colors
-pub const TEXT: Color = Color::Ansi(AnsiColor::White);
-pub const TEXT_VARIANT: Color = Color::Ansi(AnsiColor::BrightCyan);
-pub const SUCCESS: Color = Color::Ansi(AnsiColor::BrightCyan);
-pub const ERROR: Color = Color::Ansi(AnsiColor::Red);
-pub const WARNING: Color = Color::Ansi(AnsiColor::BrightYellow);

--- a/crates/twintail_common/src/lib.rs
+++ b/crates/twintail_common/src/lib.rs
@@ -1,4 +1,3 @@
-pub mod color;
 pub mod crypto;
 pub mod error;
 pub mod models;

--- a/crates/twintail_core/Cargo.toml
+++ b/crates/twintail_core/Cargo.toml
@@ -20,7 +20,6 @@ sha2.workspace = true
 futures.workspace = true
 humansize.workspace = true
 fs2.workspace = true
-indicatif.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/twintail_core/src/config/crypt_config.rs
+++ b/crates/twintail_core/src/config/crypt_config.rs
@@ -6,14 +6,12 @@ use twintail_common::{
 // constants
 const DEFAULT_SERVER: Server = Server::Japan;
 const DEFAULT_RECURSIVE: bool = false;
-const DEFAULT_QUIET: bool = false;
 
 /// Configuration for encryption and decryption.
 pub struct CryptConfig {
     pub aes_config: AesConfig,
     pub concurrency: usize,
     pub recursive: bool,
-    pub quiet: bool,
     pub pretty_json: bool,
 }
 
@@ -23,7 +21,6 @@ impl Default for CryptConfig {
             aes_config: DEFAULT_SERVER.get_aes_config(),
             concurrency: available_parallelism(),
             recursive: DEFAULT_RECURSIVE,
-            quiet: DEFAULT_QUIET,
             pretty_json: false,
         }
     }
@@ -75,15 +72,6 @@ impl CryptConfigBuilder {
     /// By default, this is false.
     pub fn recursive(mut self, recursive: bool) -> Self {
         self.config.recursive = recursive;
-        self
-    }
-
-    /// When performing operations, whether to print information
-    /// regarding the progress of the operation.
-    ///
-    /// By default, this is false.
-    pub fn quiet(mut self, quiet: bool) -> Self {
-        self.config.quiet = quiet;
         self
     }
 

--- a/crates/twintail_core/src/config/fetch_config.rs
+++ b/crates/twintail_core/src/config/fetch_config.rs
@@ -14,7 +14,6 @@ use super::OptionalBuilder;
 // constants
 const DEFAULT_SERVER: Server = Server::Japan;
 const DEFAULT_RECURSIVE: bool = false;
-const DEFAULT_QUIET: bool = false;
 const DEFAULT_PLATFORM: Platform = Platform::Android;
 const DEFAULT_RETRY: usize = 3;
 const DEFAULT_DECRYPT: bool = true;
@@ -25,7 +24,6 @@ pub struct FetchConfig<P: UrlProvider> {
     pub jwt_key: Hmac<Sha256>,
     pub concurrency: usize,
     pub recursive: bool,
-    pub quiet: bool,
     pub version: String,
     pub hash: String,
     pub platform: Platform,
@@ -62,7 +60,6 @@ impl<P: UrlProvider> FetchConfig<P> {
             url_provider,
             concurrency: available_parallelism(),
             recursive: DEFAULT_RECURSIVE,
-            quiet: DEFAULT_QUIET,
             version,
             hash,
             platform: DEFAULT_PLATFORM,
@@ -133,15 +130,6 @@ impl<P: UrlProvider> FetchConfigBuilder<P> {
     /// By default, this is false.
     pub fn recursive(mut self, recursive: bool) -> Self {
         self.config.recursive = recursive;
-        self
-    }
-
-    /// When performing operations, whether to print information
-    /// regarding the progress of the operation.
-    ///
-    /// By default, this is false.
-    pub fn quiet(mut self, quiet: bool) -> Self {
-        self.config.quiet = quiet;
         self
     }
 

--- a/crates/twintail_core/src/crypto/decrypt.rs
+++ b/crates/twintail_core/src/crypto/decrypt.rs
@@ -202,12 +202,7 @@ mod tests {
         write(&in_file_path, file_json_aes_msgpack_bytes).await?;
 
         let out_file_path = in_dir.path().join("file.json");
-        let (decrypter, _) = Decrypter::new(
-            CryptConfig::builder()
-                .quiet(true)
-                .aes(aes_config.clone())
-                .build(),
-        );
+        let (decrypter, _) = Decrypter::new(CryptConfig::builder().aes(aes_config.clone()).build());
         decrypter
             .decrypt_file_aes_msgpack(&in_file_path, &out_file_path)
             .await?;

--- a/crates/twintail_core/src/crypto/encrypt.rs
+++ b/crates/twintail_core/src/crypto/encrypt.rs
@@ -19,9 +19,7 @@ use crate::{
 
 use super::{CryptState, EncryptSuitePathState, EncryptSuiteValuesState};
 
-mod strings {
-    pub const SUITE_ENCRYPTED_FILE_NAME: &str = "_suitemasterfile";
-}
+const SUITE_ENCRYPTED_FILE_NAME: &str = "_suitemasterfile";
 
 // When deserializing suitemaster files, we have to be careful to deserialize floats as f32
 // Otherwise the game will not be able to properly read the values and crash/error.
@@ -122,10 +120,9 @@ impl Encrypter {
         // write to out directory
         for (n, result) in chunks.into_iter().enumerate() {
             let bytes = result?;
-            let out_path =
-                out_path
-                    .as_ref()
-                    .join(format!("{:02}{}", n, strings::SUITE_ENCRYPTED_FILE_NAME));
+            let out_path = out_path
+                .as_ref()
+                .join(format!("{:02}{}", n, SUITE_ENCRYPTED_FILE_NAME));
             write_file(&out_path, &bytes).await?;
         }
 
@@ -247,7 +244,7 @@ mod tests {
         "#
         .as_bytes();
 
-        let (encrypter, _) = Encrypter::new(CryptConfig::builder().quiet(true).build());
+        let (encrypter, _) = Encrypter::new(CryptConfig::default());
         encrypter.encrypt_json_bytes_aes_msgpack(json_bytes)?;
 
         Ok(())
@@ -275,7 +272,7 @@ mod tests {
         )
         .await?;
 
-        let (encrypter, _) = Encrypter::new(CryptConfig::builder().quiet(true).build());
+        let (encrypter, _) = Encrypter::new(CryptConfig::default());
         encrypter
             .encrypt_file_aes_msgpack(in_path, out_path)
             .await?;
@@ -305,7 +302,7 @@ mod tests {
         .await?;
 
         // encrypt to out_dir
-        let (encrypter, _) = Encrypter::new(CryptConfig::builder().quiet(true).build());
+        let (encrypter, _) = Encrypter::new(CryptConfig::default());
         encrypter
             .encrypt_suite_path(in_dir.path(), out_dir.path(), split_count)
             .await?;
@@ -341,12 +338,7 @@ mod tests {
 
         // encrypt in_file
         let out_file_path = in_dir.path().join("file");
-        let (encrypter, _) = Encrypter::new(
-            CryptConfig::builder()
-                .quiet(true)
-                .aes(aes_config.clone())
-                .build(),
-        );
+        let (encrypter, _) = Encrypter::new(CryptConfig::builder().aes(aes_config.clone()).build());
         encrypter
             .encrypt_file_aes_msgpack(&in_file_path, &out_file_path)
             .await?;

--- a/crates/twintail_core/src/crypto/mod.rs
+++ b/crates/twintail_core/src/crypto/mod.rs
@@ -1,1 +1,56 @@
 pub mod assetbundle;
+pub mod decrypt;
+pub mod encrypt;
+
+#[derive(Clone, Copy)]
+pub enum EncryptSuiteValuesState {
+    /// the provided number of encrypted/decrypted files are being serialized
+    SerializeStart(usize),
+    /// the provided number of values were serialized
+    Serialize(usize),
+    /// suite files have finished being encrypted/decrypted
+    Finish,
+}
+
+#[derive(Clone, Copy)]
+pub enum EncryptSuitePathState {
+    /// files are being processed
+    Process,
+}
+
+#[derive(Clone, Copy)]
+pub enum DecryptSuitePathState {
+    /// The provided number of files are being decrypted
+    Start(usize),
+    /// A file has been decrypted
+    Decrypt,
+    /// The decryption process has finished
+    Finish,
+}
+
+#[derive(Clone, Copy)]
+pub enum CryptAssetbundlePathState {
+    /// Files in the provided path are being scanned
+    Scan,
+    /// The provided number of files are being encrypted/decrypted
+    Crypt(usize),
+    /// A file was encrypted or decrypted
+    CryptFile,
+    /// The crypt operation finished
+    Finish,
+}
+
+#[derive(Clone, Copy)]
+pub enum CryptState {
+    NoState,
+    EncryptSuiteValues(EncryptSuiteValuesState),
+    EncryptSuitePath(EncryptSuitePathState),
+    DecryptSuitePath(DecryptSuitePathState),
+    AssetbundlePath(CryptAssetbundlePathState),
+}
+
+impl Default for CryptState {
+    fn default() -> Self {
+        Self::NoState
+    }
+}

--- a/crates/twintail_core/src/lib.rs
+++ b/crates/twintail_core/src/lib.rs
@@ -1,10 +1,8 @@
 pub mod apk_extractor;
 pub mod config;
-pub mod decrypt;
-pub mod encrypt;
+pub mod crypto;
 pub mod fetch;
 
-mod crypto;
 mod error;
 mod fs;
 

--- a/crates/twintail_sekai/src/sekai_client.rs
+++ b/crates/twintail_sekai/src/sekai_client.rs
@@ -253,6 +253,7 @@ impl<T: UrlProvider> SekaiClient<T> {
     pub async fn get_assetbundle_info(
         &self,
         asset_version: &str,
+        asset_hash: &str,
         asstbundle_host_hash: &str,
     ) -> Result<AssetbundleInfo, Error> {
         let request = self
@@ -260,6 +261,7 @@ impl<T: UrlProvider> SekaiClient<T> {
             .get(self.url_provider.assetbundle_info(
                 asstbundle_host_hash,
                 asset_version,
+                asset_hash,
                 &self.app.platform,
             ))
             .headers(self.headers.get_map());

--- a/crates/twintail_sekai/src/url/global_provider.rs
+++ b/crates/twintail_sekai/src/url/global_provider.rs
@@ -41,7 +41,7 @@ impl UrlProvider for GlobalUrlProvider {
         )
     }
 
-    fn assetbundle_info(&self, _: &str, asset_version: &str, platform: &Platform) -> String {
+    fn assetbundle_info(&self, _: &str, asset_version: &str, _: &str, platform: &Platform) -> String {
         format!(
             "https://assetbundle-info.urls-en.com{}/{}/os/{}",
             urls::assetbundle::INFO,

--- a/crates/twintail_sekai/src/url/global_provider.rs
+++ b/crates/twintail_sekai/src/url/global_provider.rs
@@ -41,7 +41,13 @@ impl UrlProvider for GlobalUrlProvider {
         )
     }
 
-    fn assetbundle_info(&self, _: &str, asset_version: &str, _: &str, platform: &Platform) -> String {
+    fn assetbundle_info(
+        &self,
+        _: &str,
+        asset_version: &str,
+        _: &str,
+        platform: &Platform,
+    ) -> String {
         format!(
             "https://assetbundle-info.urls-en.com{}/{}/os/{}",
             urls::assetbundle::INFO,

--- a/crates/twintail_sekai/src/url/japan_provider.rs
+++ b/crates/twintail_sekai/src/url/japan_provider.rs
@@ -45,13 +45,15 @@ impl UrlProvider for JapanUrlProvider {
         &self,
         host_hash: &str,
         asset_version: &str,
+        asset_hash: &str,
         platform: &Platform,
     ) -> String {
         format!(
-            "https://production-{}-assetbundle-info.sekai.colorfulpalette.org{}/{}/os/{}",
+            "https://production-{}-assetbundle-info.sekai.colorfulpalette.org{}/{}/{}/os/{}",
             host_hash,
             urls::assetbundle::INFO,
             asset_version,
+            asset_hash,
             platform.to_string()
         )
     }

--- a/crates/twintail_sekai/src/url/mod.rs
+++ b/crates/twintail_sekai/src/url/mod.rs
@@ -44,7 +44,7 @@ pub trait UrlProvider: Clone {
     fn user(&self) -> String;
     fn system(&self) -> String;
     fn user_auth(&self, user_id: usize) -> String;
-    fn assetbundle_info(&self, host_hash: &str, asset_version: &str, platform: &Platform)
+    fn assetbundle_info(&self, host_hash: &str, asset_version: &str, asset_hash: &str, platform: &Platform)
     -> String;
     fn assetbundle(&self, host_hash: &str, assetbundle_path: &str) -> String;
     fn assetbundle_path(

--- a/crates/twintail_sekai/src/url/mod.rs
+++ b/crates/twintail_sekai/src/url/mod.rs
@@ -44,8 +44,13 @@ pub trait UrlProvider: Clone {
     fn user(&self) -> String;
     fn system(&self) -> String;
     fn user_auth(&self, user_id: usize) -> String;
-    fn assetbundle_info(&self, host_hash: &str, asset_version: &str, asset_hash: &str, platform: &Platform)
-    -> String;
+    fn assetbundle_info(
+        &self,
+        host_hash: &str,
+        asset_version: &str,
+        asset_hash: &str,
+        platform: &Platform,
+    ) -> String;
     fn assetbundle(&self, host_hash: &str, assetbundle_path: &str) -> String;
     fn assetbundle_path(
         &self,

--- a/crates/twintail_sekai/src/url/server_provider.rs
+++ b/crates/twintail_sekai/src/url/server_provider.rs
@@ -55,11 +55,12 @@ impl UrlProvider for ServerUrlProvider {
         &self,
         host_hash: &str,
         asset_version: &str,
+        asset_hash: &str,
         platform: &Platform,
     ) -> String {
         match self {
-            Self::Japan(provider) => provider.assetbundle_info(host_hash, asset_version, platform),
-            Self::Global(provider) => provider.assetbundle_info(host_hash, asset_version, platform),
+            Self::Japan(provider) => provider.assetbundle_info(host_hash, asset_version, asset_hash, platform),
+            Self::Global(provider) => provider.assetbundle_info(host_hash, asset_version, asset_hash, platform),
         }
     }
 

--- a/crates/twintail_sekai/src/url/server_provider.rs
+++ b/crates/twintail_sekai/src/url/server_provider.rs
@@ -59,8 +59,12 @@ impl UrlProvider for ServerUrlProvider {
         platform: &Platform,
     ) -> String {
         match self {
-            Self::Japan(provider) => provider.assetbundle_info(host_hash, asset_version, asset_hash, platform),
-            Self::Global(provider) => provider.assetbundle_info(host_hash, asset_version, asset_hash, platform),
+            Self::Japan(provider) => {
+                provider.assetbundle_info(host_hash, asset_version, asset_hash, platform)
+            }
+            Self::Global(provider) => {
+                provider.assetbundle_info(host_hash, asset_version, asset_hash, platform)
+            }
         }
     }
 

--- a/crates/twintail_sekai/src/url/test_provider.rs
+++ b/crates/twintail_sekai/src/url/test_provider.rs
@@ -43,14 +43,16 @@ impl UrlProvider for TestUrlProvider {
         &self,
         host_hash: &str,
         asset_version: &str,
+        asset_hash: &str,
         platform: &Platform,
     ) -> String {
         format!(
-            "{}-{}{}/{}/os/{}",
+            "{}-{}{}/{}/{}/os/{}",
             self.host,
             host_hash,
             urls::assetbundle::INFO,
             asset_version,
+            asset_hash,
             platform.to_string()
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,6 @@ pub use twintail_sekai;
 pub use twintail_common::crypto::aes_msgpack;
 pub use twintail_common::models::serde::ValueF32;
 pub use twintail_core::apk_extractor::{ApkExtractor, AppInfo};
-pub use twintail_core::decrypt::Decrypter;
-pub use twintail_core::encrypt::Encrypter;
+pub use twintail_core::crypto::decrypt::Decrypter;
+pub use twintail_core::crypto::encrypt::Encrypter;
 pub use twintail_core::fetch::Fetcher;


### PR DESCRIPTION
The `twintail_core` crate no longer prints anything to the console, instead communicating through a channel.
`twintail_cli` now interprets messages coming through a channel to print command status to the console.